### PR TITLE
Transform only in gulp build step

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ gulp.task('browserify', function () {
       standalone: 'ReactReorderable'
     })
     .external(['create-react-class', 'prop-types', 'react', 'react-dom', 'react-drag'])
+    .transform("browserify-shim")
     .bundle()
     .pipe(source('ReactReorderable.js'))
     .pipe(buffer())

--- a/package.json
+++ b/package.json
@@ -49,11 +49,6 @@
     "react-dom": "^15.0.0 || ^16.0.0",
     "react-drag": "^2.0.0"
   },
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
   "browserify-shim": {
     "react": "global:React",
     "react-dom": "global:ReactDOM",


### PR DESCRIPTION
Having the transform in the package.json means it gets executed by anyone using this library if they are unlucky enough to be using browserify as well. Moving it into the gulp build step avoids this issue.